### PR TITLE
Fixed resize issue on shapes example. Fixed destroy on DrawImage

### DIFF
--- a/src/main/java/org/roger600/lienzo/client/ArcsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/ArcsExample.java
@@ -7,8 +7,13 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class ArcsExample extends BaseExample implements Example {
 
+	private Arc[] arcs = new Arc[30];
 	public ArcsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -20,13 +25,29 @@ public class ArcsExample extends BaseExample implements Example {
 		
 		for (int i = 0; i < 30; i++) {  
 			  
-            final Arc arc = new Arc((int) (Util.randomNumber(10, 10)), 0, (Math.PI * 2) / 2);  
-            arc.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setFillColor(Color.getRandomHexColor()).setDraggable(true)  
+            arcs[i] = new Arc((int) (Util.randomNumber(10, 10)), 0, (Math.PI * 2) / 2);  
+            arcs[i] .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setFillColor(Color.getRandomHexColor()).setDraggable(true)  
                     .setRotationDegrees(Util.randomNumber(3, 10));  
-            layer.add(arc);  
+            layer.add(arcs[i]);  
         }  
+		setLocation();
 		
+	}
+	
+
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Arcs on Resize..--->");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 30; i++) {  
+	    	 setRandomLocation(arcs[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/ArrowAttributesExample.java
+++ b/src/main/java/org/roger600/lienzo/client/ArrowAttributesExample.java
@@ -51,7 +51,22 @@ public class ArrowAttributesExample extends BaseExample implements Example {
 		detach();
     }
 	
-	private void detach() {
+
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Arrow Example on Resize N/A -->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+		// No need
+	}
+	
+	
+	public void detach() {
+		layer.clear();
 		br.remove();
         arrowTypeLabel.remove();
         select.remove();
@@ -63,6 +78,8 @@ public class ArrowAttributesExample extends BaseExample implements Example {
         arrowAngleSelect.remove();
         baseAnglelabel.remove();
         baseAngleSelect.remove();
+        layer.batch();
+        console.log("Destroying Arrow Attributes --->>");
 	}
 
 	@Override public void init(final LienzoPanel2 panel, final HTMLDivElement topDiv) {
@@ -236,21 +253,19 @@ public class ArrowAttributesExample extends BaseExample implements Example {
 		
 	}
 	
-	public static class DragHandle extends Group implements NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler  
-    {  
+	public static class DragHandle extends Group implements NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler  {  
         private Arrow arrow, dragArrow;  
         private boolean start;  
           
-        public DragHandle(String text, boolean start, Arrow arrow, Arrow dragArrow)  
-        {  
-            Circle c = new Circle(3);  
-            c.setFillColor(ColorName.BLACK.getColor().setA(0.5));  
-            add(c);  
+        public DragHandle(String text, boolean start, Arrow arrow, Arrow dragArrow) {  
+            Circle circle = new Circle(3);  
+            circle.setFillColor(ColorName.BLACK.getColor().setA(0.5));  
+            add(circle);  
               
-            Text t = new Text(text, "Arial, sans-serif", 10);  
-            t.setX(-10).setY(15);  
-            t.setFillColor(ColorName.BLACK);  
-            add(t);  
+            Text txt = new Text(text, "Arial, sans-serif", 10);  
+            txt.setX(-10).setY(15);  
+            txt.setFillColor(ColorName.BLACK);  
+            add(txt);  
               
             this.arrow = arrow;  
             this.dragArrow = dragArrow;  
@@ -265,16 +280,16 @@ public class ArrowAttributesExample extends BaseExample implements Example {
         @Override  
         public void onNodeDragStart(NodeDragStartEvent event) {  
               
-            if (dragArrow.getParent() == null)  
-            {  
+            if (dragArrow.getParent() == null)  {  
                 getViewport().getDragLayer().add(dragArrow);  
                 dragArrow.moveToBottom();  
             }  
               
-            if (start)  
+            if (start) {
                 dragArrow.setStart(new Point2D(event.getX(), event.getY()));  
-            else  
+            } else {  
                 dragArrow.setEnd(new Point2D(event.getX(), event.getY()));  
+            }
               
             dragArrow.setVisible(true);  
             arrow.getScene().draw();  
@@ -282,10 +297,12 @@ public class ArrowAttributesExample extends BaseExample implements Example {
   
         @Override  
         public void onNodeDragMove(NodeDragMoveEvent event) {  
-            if (start)  
-                dragArrow.setStart(new Point2D(event.getX(), event.getY()));  
-            else  
+            if (start) {
+                dragArrow.setStart(new Point2D(event.getX(), event.getY())); 
+            } else {  
                 dragArrow.setEnd(new Point2D(event.getX(), event.getY()));   
+            }
+            
             arrow.setStrokeColor(ColorName.GRAY); 
             arrow.setFillColor(ColorName.TRANSPARENT);   
             arrow.setStart(dragArrow.getStart());  
@@ -295,10 +312,11 @@ public class ArrowAttributesExample extends BaseExample implements Example {
   
         @Override  
         public void onNodeDragEnd(NodeDragEndEvent event) {   
-            if (start)  
+            if (start)  {
                 dragArrow.setStart(new Point2D(event.getX(), event.getY()));  
-            else  
+            } else {  
                 dragArrow.setEnd(new Point2D(event.getX(), event.getY()));  
+            }
   
             dragArrow.setVisible(false);  
               
@@ -313,8 +331,7 @@ public class ArrowAttributesExample extends BaseExample implements Example {
     }  
   
     public void update(int baseWidth, int headWidth, int arrowAngle, int baseAngle, ArrowType arrowType) {  
-        for (int i = 0; i < 2; i++)  
-        {  
+        for (int i = 0; i < 2; i++)  {  
             Arrow a = arrows[i];  
             a.setBaseWidth(baseWidth);  
             a.setHeadWidth(headWidth);  

--- a/src/main/java/org/roger600/lienzo/client/ArrowsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/ArrowsExample.java
@@ -11,8 +11,14 @@ import com.ait.lienzo.shared.core.types.LineJoin;
 
 public class ArrowsExample extends BaseExample implements Example {
 
+	private Arrow[] arrows = new Arrow[40];
+	
 	public ArrowsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -38,26 +44,40 @@ public class ArrowsExample extends BaseExample implements Example {
             double arrowAngle = Util.randomDoubleBetween(25, 70);  
             double baseAngle = Util.randomDoubleBetween(15, 100 - arrowAngle);  
               
-            final Arrow arrow = new Arrow(new Point2D(x1, y1), new Point2D(x2, y2),   
+            arrows[i] = new Arrow(new Point2D(x1, y1), new Point2D(x2, y2),   
                     baseWidth, headWidth, arrowAngle, baseAngle,   
                     Util.randomValue(ArrowType.values()));  
               
             int strokeWidth = Util.randomIntBetween(1, 10);  
               
-            arrow.setShadow(new Shadow("black", 6, 6, 6))  
+            arrows[i].setShadow(new Shadow("black", 6, 6, 6))  
                 .setFillColor(Color.getRandomHexColor())  
                 .setStrokeWidth(strokeWidth)  
                 .setStrokeColor(Color.getRandomHexColor())  
                 .setLineJoin(Util.randomValue(LineJoin.values()))  
                 .setDraggable(true);  
               
-            layer.add(arrow);  
+            layer.add(arrows[i]);  
               
             i++;  
         }  
-		
-		
+		setLocation();
+		layer.draw();
 	}
-
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Arrows Example on Resize.-->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 40; i++) {  
+	    	 setRandomLocation(arrows[i]);
+	    }
+	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/CircleExample.java
+++ b/src/main/java/org/roger600/lienzo/client/CircleExample.java
@@ -7,8 +7,14 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class CircleExample extends BaseExample implements Example {
 
+	private Circle[] circles = new Circle[40];
+	
 	public CircleExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -19,14 +25,29 @@ public class CircleExample extends BaseExample implements Example {
 	public void run() {
 
 		for (int i = 0; i < 40; i++) {  
-			  
-            final Circle circle = new Circle(Util.randomNumber(8, 10));  
-            circle.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
-            layer.add(circle);  
+            circles[i] = new Circle(Util.randomNumber(8, 10));  
+            circles[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
+            layer.add(circles[i]);  
   
         }  
+		setLocation();
+		layer.draw();
 		
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Circle Example on Resize.-->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 40; i++) {  
+	    	 setRandomLocation(circles[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/CubicCurveExample.java
+++ b/src/main/java/org/roger600/lienzo/client/CubicCurveExample.java
@@ -1,15 +1,19 @@
 package org.roger600.lienzo.client;
 
-import org.roger600.Util;
-
 import com.ait.lienzo.client.core.shape.BezierCurve;
 import com.ait.lienzo.shared.core.types.Color;
 import com.ait.lienzo.shared.core.types.LineCap;
 
 public class CubicCurveExample extends BaseExample implements Example {
 
+	private BezierCurve[] curves = new BezierCurve[30];
+	
 	public CubicCurveExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 50;
+		leftPadding = 0;
 	}
 
 	public void destroy() {
@@ -20,12 +24,27 @@ public class CubicCurveExample extends BaseExample implements Example {
 	public void run() {
 		
 		for (int i = 0; i < 30; i++) {  
-            final BezierCurve bezierCurve = new BezierCurve(188, 130, 140, 10, 388, 10, 388, 170);  
-            bezierCurve.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setDraggable(true).setLineCap(LineCap.ROUND);  
-            layer.add(bezierCurve);  
+            curves[i] = new BezierCurve(188, 130, 140, 10, 388, 10, 388, 170);  
+            curves[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(2).setDraggable(true).setLineCap(LineCap.ROUND);  
+            layer.add(curves[i]);  
         }  
+		setLocation();
 		
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Cubic Curve Example on Resize --->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 30; i++) {  
+	    	 setRandomLocation(curves[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/DashedLinesExample.java
+++ b/src/main/java/org/roger600/lienzo/client/DashedLinesExample.java
@@ -2,10 +2,14 @@ package org.roger600.lienzo.client;
 
 import com.ait.lienzo.client.core.shape.Line;
 import com.ait.lienzo.client.core.types.DashArray;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.shared.core.types.Color;
 
 public class DashedLinesExample extends BaseExample implements Example {
 
+	private Line[] lines = new Line[10];
+	
 	public DashedLinesExample(String title) {
 		super(title);
 	}
@@ -26,14 +30,33 @@ public class DashedLinesExample extends BaseExample implements Example {
         final DashArray dashes = new DashArray(10, 10);  
           
         for (int i = 0; i < 10; i++) {  
-            Line line = new Line(x1,y1, x2, y2);  
-            line.setDashArray(dashes);  
-            line.setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(1+i).setFillColor(Color.getRandomHexColor());  
-            layer.add(line);  
+            lines[i] = new Line(x1,y1, x2, y2);  
+            lines[i].setDashArray(dashes);  
+            lines[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(1+i).setFillColor(Color.getRandomHexColor());  
+            layer.add(lines[i]);  
             y1 += 50;  
             y2 += 50;  
         }  
-		
 	}
-
+	
+	 @Override
+	    public void onResize() {
+	        super.onResize();
+	        console.log("ReDrawing Dashed Lines on Resize...--->>");
+	    
+	        final double x1 = width * 0.25;  
+	        double y1 = height * 0.15;  
+           
+	        final double x2 = width * 0.75;  
+	        double y2 = height * 0.15;  
+	        
+	        for (Line line: lines) {
+	        	Point2D p1 = new Point2D(x1, y1);
+	        	Point2D p2 = new Point2D(x2, y2);
+	        	line.setPoint2DArray(Point2DArray.fromArrayOfPoint2D(p1, p2));
+	        	y1 += 50;  
+	            y2 += 50;  
+	        }
+	        layer.batch();
+	    }
 }

--- a/src/main/java/org/roger600/lienzo/client/DrawImageExample.java
+++ b/src/main/java/org/roger600/lienzo/client/DrawImageExample.java
@@ -266,6 +266,9 @@ public class DrawImageExample extends BaseExample implements Example
     @Override public void destroy()
     {
         super.destroy();
+        select.remove();
+        slider.remove();
         pictures = null;
+        console.log("Destroying Draw Image ->");
     }
 }

--- a/src/main/java/org/roger600/lienzo/client/EllipseExample.java
+++ b/src/main/java/org/roger600/lienzo/client/EllipseExample.java
@@ -1,14 +1,17 @@
 package org.roger600.lienzo.client;
 
-import org.roger600.Util;
-
 import com.ait.lienzo.client.core.shape.Ellipse;
 import com.ait.lienzo.shared.core.types.Color;
 
 public class EllipseExample extends BaseExample implements Example {
 
+	private Ellipse[] ellipses = new Ellipse[40];
 	public EllipseExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -17,16 +20,30 @@ public class EllipseExample extends BaseExample implements Example {
 
 	@Override
 	public void run() {
+		final int strokeWidth = 1;  
 		
 		for (int i = 0; i < 40; i++) {  
-			  
-            final int strokeWidth = 1;  
-            final Ellipse ellipse = new Ellipse(Math.random() * 160, Math.random() * 80);  
-            ellipse.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
-            layer.add(ellipse);  
+		    ellipses[i] = new Ellipse(Math.random() * 160, Math.random() * 80);  
+            ellipses[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
+            layer.add(ellipses[i]);  
         }  
+		setLocation();
 		
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Ellipses Example on Resize ->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 40; i++) {  
+	    	 setRandomLocation(ellipses[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/GroupsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/GroupsExample.java
@@ -8,8 +8,14 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class GroupsExample extends BaseExample implements Example {
 
+	private Star[] stars = new Star[5];
+	
 	public GroupsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -23,14 +29,27 @@ public class GroupsExample extends BaseExample implements Example {
   
         for (int i = 0; i < 5; i++) {  
             final int strokeWidth = Util.randomNumber(2, 10);  
-            final Star star = new Star((int) (Math.random() * 10), 25, 50);  
-            star.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor());  
-            group.add(star);  
+            stars[i] = new Star((int) (Math.random() * 10), 25, 50);  
+            stars[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor());  
+            group.add(stars[i]);  
         }  
-  
-        layer.add(group);  
-		
+        setLocation();
+        layer.add(group);
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Group Example on Resize --->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 5; i++) {  
+	    	 setRandomLocation(stars[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/LineJoinsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/LineJoinsExample.java
@@ -1,15 +1,19 @@
 package org.roger600.lienzo.client;
 
-import org.roger600.Util;
-
 import com.ait.lienzo.client.core.shape.Star;
 import com.ait.lienzo.shared.core.types.Color;
 import com.ait.lienzo.shared.core.types.LineJoin;
 
 public class LineJoinsExample extends BaseExample implements Example {
 
+	private Star[] stars = new Star[15];
+	
 	public LineJoinsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -19,27 +23,42 @@ public class LineJoinsExample extends BaseExample implements Example {
 	@Override
 	public void run() {
 		
-		for (int i = 0; i < 5; i++) {  
+		for (int i = 0; i < 15; i++) {  
 			  
-            Star star = new Star(5, 30, 80);  
-            star.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
-                    .setLineJoin(LineJoin.BEVEL).setStrokeWidth(15).setDraggable(true);  
-            layer.add(star);  
-  
-            star = new Star(10, 30, 80);  
-            star.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
-                    .setLineJoin(LineJoin.MITER).setStrokeWidth(15).setDraggable(true);  
-            layer.add(star);  
-  
-            star = new Star(7, 30, 80);  
-            star.setX(Util.generateValueWithinBoundary(width, 125)).setY(Util.generateValueWithinBoundary(height, 125))  
-                    .setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
-                    .setLineJoin(LineJoin.ROUND).setStrokeWidth(15).setDraggable(true);  
-            layer.add(star);  
+			if (i % 3 == 0) {
+				stars[i] = new Star(5, 30, 80);  
+				stars[i].setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
+                .setLineJoin(LineJoin.BEVEL).setStrokeWidth(15).setDraggable(true);  
+			} else if (i % 3 == 1) {
+				stars[i] = new Star(10, 30, 80);  
+				stars[i].setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
+                .setLineJoin(LineJoin.MITER).setStrokeWidth(15).setDraggable(true);  
+			} else if (i % 3 == 2) {
+				stars[i] = new Star(7, 30, 80);  
+				stars[i].setStrokeColor(Color.getRandomHexColor()).setFillColor(Color.getRandomHexColor())  
+                .setLineJoin(LineJoin.ROUND).setStrokeWidth(15).setDraggable(true);  
+			}
+            
+            layer.add(stars[i]);  
         }  
+		setLocation();
 		
 	}
-
+	
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Line Joins on Resize...--->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 15; i++) {  
+	    	 setRandomLocation(stars[i]);
+	    }
+	}
+	
 }

--- a/src/main/java/org/roger600/lienzo/client/LinesCapExample.java
+++ b/src/main/java/org/roger600/lienzo/client/LinesCapExample.java
@@ -1,11 +1,15 @@
 package org.roger600.lienzo.client;
 
 import com.ait.lienzo.client.core.shape.Line;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.shared.core.types.Color;
 import com.ait.lienzo.shared.core.types.LineCap;
 
 public class LinesCapExample extends BaseExample implements Example {
 
+	private Line[] lines = new Line[3];
+	
 	public LinesCapExample(String title) {
 		super(title);
 	}
@@ -16,20 +20,34 @@ public class LinesCapExample extends BaseExample implements Example {
 
 	@Override
 	public void run() {
-		final int middleX = width / 2;  
-        final int middleY = height / 2;  
+		lines[0] = new Line();  
+        lines[0].setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.BUTT);  
+        layer.add(lines[0]);  
   
-        Line line = new Line(middleX - middleX / 2, middleY - 100, middleX + middleX / 2, middleY - 100);  
-        line.setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.BUTT);  
-        layer.add(line);  
+        lines[1] = new Line();  
+        lines[1].setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.ROUND);  
+        layer.add(lines[1]);  
   
-        line = new Line(middleX - middleX / 2, middleY, middleX + middleX / 2, middleY);  
-        line.setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.ROUND);  
-        layer.add(line);  
-  
-        line = new Line(middleX - middleX / 2, middleY + 100, middleX + middleX / 2, middleY + 100);  
-        line.setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.SQUARE);  
-        layer.add(line);  
+        lines[2] = new Line();  
+        lines[2].setStrokeWidth(30).setFillColor(Color.getRandomHexColor()).setStrokeColor(Color.getRandomHexColor()).setLineCap(LineCap.SQUARE);  
+        layer.add(lines[2]);  
+        setLocation();
 	}
-
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Caps on Lines on Resize...--->>>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+		final int middleX = width / 2;  
+	    final int middleY = height / 2;
+	    
+		lines[0].setPoint2DArray(Point2DArray.fromArrayOfPoint2D(new Point2D(middleX - middleX / 2, middleY - 100), new Point2D(middleX + middleX / 2, middleY - 100)));
+        lines[1].setPoint2DArray(Point2DArray.fromArrayOfPoint2D(new Point2D(middleX - middleX / 2, middleY), new Point2D(middleX + middleX / 2, middleY)));
+        lines[2].setPoint2DArray(Point2DArray.fromArrayOfPoint2D(new Point2D(middleX - middleX / 2, middleY + 100), new Point2D(middleX + middleX / 2, middleY + 100)));
+     }
 }

--- a/src/main/java/org/roger600/lienzo/client/LinesExample.java
+++ b/src/main/java/org/roger600/lienzo/client/LinesExample.java
@@ -1,10 +1,13 @@
 package org.roger600.lienzo.client;
 
 import com.ait.lienzo.client.core.shape.Line;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.shared.core.types.Color;
 
 public class LinesExample extends BaseExample implements Example {
 
+	private Line[] lines = new Line[10];
 	public LinesExample(String title) {
 		super(title);
 	}
@@ -23,13 +26,32 @@ public class LinesExample extends BaseExample implements Example {
         double y2 = height * 0.15;  
   
         for (int i = 0; i < 10; i++) {  
-            Line line = new Line(x1,y1, x2, y2);  
-            line.setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(1+i).setFillColor(Color.getRandomHexColor());  
-            layer.add(line);  
+            lines[i] = new Line(x1,y1, x2, y2);  
+            lines[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(1+i).setFillColor(Color.getRandomHexColor());  
+            layer.add(lines[i]);  
             y1 += 50;  
             y2 += 50;  
         }  
-		
 	}
-
+	
+	 @Override
+	    public void onResize() {
+	        super.onResize();
+	        console.log("ReDrawing Lines on Resize...--->>");
+	    
+	        final double x1 = width * 0.25;  
+            double y1 = height * 0.15;  
+              
+            final double x2 = width * 0.75;  
+            double y2 = height * 0.15;  
+	        
+	        for (Line line: lines) {
+	        	Point2D p1 = new Point2D(x1, y1);
+	        	Point2D p2 = new Point2D(x2, y2);
+	        	line.setPoint2DArray(Point2DArray.fromArrayOfPoint2D(p1, p2));
+	        	y1 += 50;  
+	            y2 += 50;  
+	        }
+	        layer.batch();
+	    }
 }

--- a/src/main/java/org/roger600/lienzo/client/MovieExample.java
+++ b/src/main/java/org/roger600/lienzo/client/MovieExample.java
@@ -80,6 +80,7 @@ public class MovieExample extends BaseExample implements Example
         movie.stop();
         movie = null;
         text = null;
+        
         super.destroy();
     }
 }

--- a/src/main/java/org/roger600/lienzo/client/PolygonsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/PolygonsExample.java
@@ -9,8 +9,14 @@ import com.ait.lienzo.shared.core.types.LineJoin;
 
 public class PolygonsExample extends BaseExample implements Example {
 
+	private RegularPolygon[] polys = new RegularPolygon[40];
+	
 	public PolygonsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -20,15 +26,34 @@ public class PolygonsExample extends BaseExample implements Example {
 	@Override
 	public void run() {
 		
+		
 		for (int i = 0; i < 40; i++) {  
-            final int strokeWidth = Util.randomNumber(2, 10);  
-            final RegularPolygon polygon = new RegularPolygon(8, 60);  
-            polygon.setShadow(new Shadow("black", 6, 6, 6)).setFillColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth)  
-                    .setStrokeColor(Color.getRandomHexColor()).setLineJoin(LineJoin.ROUND).setX(Util.generateValueWithinBoundary(width, 125))  
-                    .setY(Util.generateValueWithinBoundary(height, 125)).setDraggable(true);  
-            layer.add(polygon);  
+			final int strokeWidth = Util.randomNumber(2, 10);  
+	        
+            polys[i] = new RegularPolygon(8, 60);  
+            polys[i].setShadow(new Shadow("black", 6, 6, 6)).setFillColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth)  
+                    .setStrokeColor(Color.getRandomHexColor()).setLineJoin(LineJoin.ROUND)
+                    .setDraggable(true);  
+            layer.add(polys[i]);  
         }  
 		
+		setLocation();
+		
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Polygons Example on Resize --->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 40; i++) {  
+	    	 setRandomLocation(polys[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/QuadraticCurveExample.java
+++ b/src/main/java/org/roger600/lienzo/client/QuadraticCurveExample.java
@@ -8,8 +8,14 @@ import com.ait.lienzo.shared.core.types.LineCap;
 
 public class QuadraticCurveExample extends BaseExample implements Example {
 
+	private QuadraticCurve[] curves = new QuadraticCurve[30];
+	
 	public QuadraticCurveExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 120;
+		leftPadding = -50;
 	}
 
 	public void destroy() {
@@ -19,14 +25,30 @@ public class QuadraticCurveExample extends BaseExample implements Example {
 	@Override
 	public void run() {
 		
+		final int strokeWidth = Util.randomNumber(2, 10);  
+        
 		for (int i = 0; i < 30; i++) {  
-            final int strokeWidth = Util.randomNumber(2, 10);  
-            final QuadraticCurve quadraticCurve = new QuadraticCurve(130, 130, 200, 0, 230, 130);  
-            quadraticCurve.setX(Util.generateValueWithinBoundary(width, 40)).setY(Util.generateValueWithinBoundary(height, 100))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setDraggable(true).setLineCap(LineCap.ROUND);  
-            layer.add(quadraticCurve);  
+            curves[i] = new QuadraticCurve(130, 130, 200, 0, 230, 130);  
+            curves[i].setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setDraggable(true).setLineCap(LineCap.ROUND);  
+            layer.add(curves[i]);  
         }  
 		
+		setLocation();
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Quadratic Curve Example on Resize ->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 30; i++) {  
+	    	 setRandomLocation(curves[i]);
+	    }
 	}
 
 }

--- a/src/main/java/org/roger600/lienzo/client/RectangleExample.java
+++ b/src/main/java/org/roger600/lienzo/client/RectangleExample.java
@@ -7,8 +7,12 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class RectangleExample extends BaseExample implements Example {
 
+	private Rectangle[] rectangles = new Rectangle[30];
+	
 	public RectangleExample(String title) {
 		super(title);
+		 topPadding = 20;
+		 bottomPadding = 100;
 	}
 	
 	public void destroy() {
@@ -20,12 +24,27 @@ public class RectangleExample extends BaseExample implements Example {
 		
 		for (int i = 0; i < 30; i++) {  
             final int strokeWidth = 1;  
-            final Rectangle rectangle = new Rectangle(Math.random() * 220, Math.random() * 160);  
-            rectangle.setX(Util.generateValueWithinBoundary(width, 0)).setY(Util.generateValueWithinBoundary(height, 0))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
-            layer.add(rectangle);  
-        }  
+            rectangles[i] = new Rectangle(Math.random() * 220, Math.random() * 160) 
+            .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
+            layer.add(rectangles[i]);  
+        }
+		 setLocation();
+		 layer.draw();
 		
 	}
+	
+	 @Override
+	    public void onResize() {
+	        super.onResize();
+	        setLocation();
+	        layer.batch();
+	    }
+
+	    private void setLocation() {
+	    	console.log("Random Location for Rectangles --->###..#");
+	        for (int i = 0; i < rectangles.length; i++) {
+	            setRandomLocation(rectangles[i]);
+	        }
+	    }
 
 }

--- a/src/main/java/org/roger600/lienzo/client/RoundedCornersExample.java
+++ b/src/main/java/org/roger600/lienzo/client/RoundedCornersExample.java
@@ -7,8 +7,12 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class RoundedCornersExample extends BaseExample implements Example {
 
+	private Rectangle[] rectangles = new Rectangle[30];
+	
 	public RoundedCornersExample(String title) {
 		super(title);
+		 topPadding = 20;
+		 bottomPadding = 100;
 	}
 
 	public void destroy() {
@@ -20,14 +24,28 @@ public class RoundedCornersExample extends BaseExample implements Example {
 		
 		for (int i = 0; i < 30; i++) {  
             final int strokeWidth = 1;  
-  
-            final Rectangle rectangle = new Rectangle(generateNumber(220), generateNumber(160), 20);  
-            rectangle.setX(Util.generateValueWithinBoundary(width, 0)).setY(Util.generateValueWithinBoundary(height, 0))  
-                    .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
-            layer.add(rectangle);  
-  
+            rectangles[i] = new Rectangle(generateNumber(220), generateNumber(160), 20)
+            .setStrokeColor(Color.getRandomHexColor()).setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
+            layer.add(rectangles[i]); 
         }  
+		setLocation();
+		layer.draw();
 	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        setLocation();
+        layer.batch();
+    }
+
+    private void setLocation() {
+    	console.log("Random Location");
+        for (int i = 0; i < rectangles.length; i++) {
+            setRandomLocation(rectangles[i]);
+        }
+    }
+
 	
 	private double generateNumber(int number) {  
         double result = Math.random() * number;  

--- a/src/main/java/org/roger600/lienzo/client/ShapesExample.java
+++ b/src/main/java/org/roger600/lienzo/client/ShapesExample.java
@@ -10,8 +10,7 @@ import elemental2.dom.Element.OnclickFn;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 
-public class ShapesExample extends BaseExample implements Example
-{
+public class ShapesExample extends BaseExample implements Example {
  
     private HTMLButtonElement rectangleButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
     private HTMLButtonElement roundedCornersRectangleButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
@@ -49,14 +48,15 @@ public class ShapesExample extends BaseExample implements Example
 	private GroupsExample groupsExample = new GroupsExample("Groups Example");
 	private SliceGroupExample sliceGroupExample = new SliceGroupExample("Slice Group Example");
 	
+	private Example currentExample = null;
     public ShapesExample(final String title) {
         super(title);
-        heightOffset = 60;
+        heightOffset = 0;
     }
 
     @Override
 	public void destroy() {
-		super.destroy();
+    	super.destroy();
 		rectangleButton.remove();
 		roundedCornersRectangleButton.remove();
 		linesButton.remove();
@@ -74,6 +74,16 @@ public class ShapesExample extends BaseExample implements Example
 		starsButton.remove();
 		groupsButton.remove();
 		sliceGroupButton.remove();
+		
+		console.log("Destroying Shapes Demo 1-->>#");
+		
+		
+		if (currentExample != null && currentExample == arrowAttributesExample) {
+			arrowAttributesExample.detach();
+		}
+	    
+		console.log("Destroying Shapes Demo -->>>#");
+		
     }
     
     @Override public void init(final LienzoPanel2 panel, final HTMLDivElement topDiv) {
@@ -137,14 +147,34 @@ public class ShapesExample extends BaseExample implements Example
     	starsButton.onclick = (e) -> {return addSubExample(starsExample);};
     	groupsButton.onclick = (e) -> {return addSubExample(groupsExample);};
     	sliceGroupButton.onclick = (e) -> {return addSubExample(sliceGroupExample);};
-    	
     }
     
     private OnclickFn addSubExample(Example example) {
     	panel.removeAll();
     	example.init(panel,  topDiv);
     	example.run();
+    	
+    	 if (currentExample != null && currentExample == arrowAttributesExample) {
+    		 	console.log("Destroying Previous Shapes Example--->>##");
+    		 	arrowAttributesExample.detach();
+    			currentExample = null;
+    	 }
+    	
+    	currentExample = example;
     	return null;
+    }
+    
+    @Override
+    public void onResize() {
+    	console.log("Resizing Call");
+        super.onResize();
+        
+        if (currentExample != null ) {
+        	currentExample.onResize();
+        }
+        
+        layer.batch();
+      
     }
         
 }

--- a/src/main/java/org/roger600/lienzo/client/SliceGroupExample.java
+++ b/src/main/java/org/roger600/lienzo/client/SliceGroupExample.java
@@ -7,8 +7,14 @@ import com.ait.lienzo.shared.core.types.ColorName;
 
 public class SliceGroupExample extends BaseExample implements Example {
 
+	private SliceGroup sliceGroup;
+	
 	public SliceGroupExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -17,47 +23,92 @@ public class SliceGroupExample extends BaseExample implements Example {
 
 	@Override
 	public void run() {
-		final int w = width/2;  
-        final int h = height/2;  
+		final int w = width / 2;  
+        final int h = height / 2;  
           
-        final SliceGroup s = new SliceGroup(w);  
-        s.setRotation(-Math.PI / 2);  
-        s.setX(w - w/2).setY(h + w/2);  
+        sliceGroup = new SliceGroup(w);  
+        sliceGroup.setRotation(-Math.PI / 2);  
+        sliceGroup.setX(w - w/2).setY(h + w/2);  
           
-        layer.add(s); 
+        layer.add(sliceGroup); 
 	}
+	
+
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Slice Group Example on Resize --->>>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+		final int w = width / 2;  
+        final int h = height / 2; 
+        
+	    sliceGroup.resize(w);
+	    sliceGroup.setX(w - w/2).setY(h + w/2); 
+	}
+	
 	
 	private class SliceGroup extends Group {  
   	  
-        public SliceGroup(double w) {  
+		private Slice[] slices = new Slice[3];
+		private Rectangle rectangle;
+		
+		private double width;
+		
+        public SliceGroup(double width) {  
   
-            add(new Rectangle(w, w).setStrokeColor(ColorName.BLACK.getValue()));  
+        	this.width = width;
+        	rectangle = new Rectangle(width, width).setStrokeColor(ColorName.BLACK.getValue());
+        	add(rectangle);  
   
-            final double r = w / 4;  
+            final double radius = width / 4;  
               
-            Slice s = new Slice(r, 0, Math.PI / 2, true);  
-            s.setX(r).setY(r);  
-            s.setFillColor(ColorName.RED.getValue());  
-            s.setAlpha(0.5);  
-            s.setDraggable(true);  
-            add(s);  
+            slices[0] = new Slice(radius, 0, Math.PI / 2, true);  
+            slices[0].setX(radius).setY(radius);
+            slices[0].setFillColor(ColorName.RED.getValue());  
+            slices[0].setAlpha(0.5);  
+            slices[0].setDraggable(true);  
+            add(slices[0]);  
   
-            s = new Slice(r, 0.75 * Math.PI, 3 * Math.PI / 2, true);  
-            s.setX(3 * r).setY(r);  
-            s.setScale(0.5);  
-            s.setFillColor(ColorName.GREEN.getValue());  
-            s.setAlpha(0.5);  
-            s.setDraggable(true);  
-            add(s);  
+            slices[1] = new Slice(radius, 0.75 * Math.PI, 3 * Math.PI / 2, true);  
+            slices[1].setX(3 * radius).setY(radius);  
+            slices[1].setScale(0.5);  
+            slices[1].setFillColor(ColorName.GREEN.getValue());  
+            slices[1].setAlpha(0.5);  
+            slices[1].setDraggable(true);  
+            add(slices[1]);  
   
-            s = new Slice(r, 0, Math.PI);  
-            s.setX(r).setY(3 * r);  
-            s.setRotation(Math.PI / 4);  
-            s.setFillColor(ColorName.BLUE.getValue());  
-            s.setAlpha(0.5);  
-            s.setDraggable(true);  
-            add(s);  
+            slices[2] = new Slice(radius, 0, Math.PI);  
+            slices[2].setX(radius).setY(3 * radius);  
+            slices[2].setRotation(Math.PI / 4);  
+            slices[2].setFillColor(ColorName.BLUE.getValue());  
+            slices[2].setAlpha(0.5);  
+            slices[2].setDraggable(true);  
+            add(slices[2]);  
         }  
+        
+        public void resize(int width) {
+        	this.width = width;
+        	setSizeAndLocation();
+        }
+        
+        public void setSizeAndLocation() {
+        	final double radius = width / 4;  
+        	rectangle.setWidth(width);
+        	rectangle.setHeight(width);
+        	
+        	slices[0].setRadius(radius).setStartAngle(0).setEndAngle(Math.PI / 2).setCounterClockwise(true)
+        	.setX(radius).setY(radius);
+        	
+        	slices[1].setRadius(radius).setStartAngle(0.75 * Math.PI).setEndAngle(3 * Math.PI / 2).setCounterClockwise(true)
+        	.setX(3 * radius).setY(radius);
+        	
+        	slices[2].setRadius(radius).setStartAngle(0).setEndAngle(Math.PI)
+        	.setX(radius).setY(3 * radius);  
+        }
   
     }  
 

--- a/src/main/java/org/roger600/lienzo/client/StarsExample.java
+++ b/src/main/java/org/roger600/lienzo/client/StarsExample.java
@@ -7,8 +7,14 @@ import com.ait.lienzo.shared.core.types.Color;
 
 public class StarsExample extends BaseExample implements Example {
 
+	private Star[] stars = new Star[40];
+	
 	public StarsExample(String title) {
 		super(title);
+		topPadding = 20;
+		bottomPadding = 100;
+		rightPadding = 30;
+		leftPadding = 20;
 	}
 
 	public void destroy() {
@@ -20,13 +26,29 @@ public class StarsExample extends BaseExample implements Example {
 		
 		for (int i = 0; i < 40; i++) {  
             final int strokeWidth = Util.randomNumber(2, 10);  
-            Star star = new Star((int) (Math.random() * 10), 25, 50);  
-            star.setX(Util.generateValueWithinBoundary(width, 50)).setY(Util.generateValueWithinBoundary(height, 50)).setStrokeColor(Color.getRandomHexColor())  
+            stars[i] = new Star((int) (Math.random() * 10), 25, 50);  
+            stars[i].setStrokeColor(Color.getRandomHexColor())  
                     .setStrokeWidth(strokeWidth).setFillColor(Color.getRandomHexColor()).setDraggable(true);  
   
-            layer.add(star);  
+            layer.add(stars[i]);  
         }  
 		
+		setLocation();
+	}
+	
+	@Override
+    public void onResize() {
+        super.onResize();
+        console.log("ReDrawing Stars Example on Resize --->>");
+        setLocation();   	
+        layer.batch();
+    }
+	
+	private void setLocation() {
+	    
+	    for (int i = 0; i < 40; i++) {  
+	    	 setRandomLocation(stars[i]);
+	    }
 	}
 
 }


### PR DESCRIPTION
Fixed resize issue on Shape Examples, now all of them work as expected, plus the ArrowProperties work when going to another example (destroying) also fixed DrawImage Destroy (was missing)